### PR TITLE
Fixed decimals going missing on toLoc, added a test to check

### DIFF
--- a/maidenhead/__init__.py
+++ b/maidenhead/__init__.py
@@ -29,11 +29,11 @@ def toLoc(maiden):
         lat += int(maiden[3])*1
 #%%
     if N>=6:
-        lon += (ord(maiden[4])-o) * 5/60
+        lon += (ord(maiden[4])-o) * 5.0/60
         lat += (ord(maiden[5])-o) * 2.5/60
 #%%
     if N>=8:
-        lon += int(maiden[6]) * 5/600
+        lon += int(maiden[6]) * 5.0/600
         lat += int(maiden[7]) * 2.5/600
 
     return lat,lon

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,6 +28,11 @@ class BasicTests(unittest.TestCase):
         g1 = maidenhead.genGoogleMap(m1)
         self.assertNotEqual(g,g1)
 
+    def test_decimals(self):
+        lat, lon = maidenhead.toLoc('JO32ii09')
+        self.assertEqual(lat, 52.37083333333334)
+        self.assertEqual(lon, 6.666666666666667)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Integer division was causing decimals to go missing. E.g. JO32ii09 was giving 52.37083333333334, 6 